### PR TITLE
Prevent extra dispatch after external state change

### DIFF
--- a/examples/links/index.js
+++ b/examples/links/index.js
@@ -2,11 +2,16 @@ import { routerStateReducer, reduxRouteComponent, transitionTo } from '../../src
 import { LOCATION_DID_CHANGE } from '../../src/actionTypes';
 import { history } from 'react-router/lib/BrowserHistory';
 import { createStore } from 'redux';
-import { Connector } from 'redux/react';
+import { Connector } from 'react-redux';
+import { batchedUpdates } from 'redux-batched-updates';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Router, Route, Link } from 'react-router';
 import pure from 'react-pure-component';
+
+import devTools from './redux-devtools/index';
+import DebugPanel from './redux-devtools/DebugPanel';
+import ReduxMonitor from './redux-devtools/ReduxMonitor';
 
 function reducer(state = {}, action) {
   return {
@@ -14,30 +19,27 @@ function reducer(state = {}, action) {
   };
 }
 
+const store = batchedUpdates(devTools()(createStore))(reducer);
 const store = createStore(reducer);
 
-const barState = {
-  pathname: '/bar',
+const redState = {
+  pathname: '/color',
   query: {
-    baz: 'foo'
+    hex: 'f00'
   },
-  navigationType: 'POP',
   state: {
     key: 'fbfv9pchy83t0529'
-  },
-  params: {}
+  }
 };
 
-const fooState = {
-  pathname: '/foo',
+const blueState = {
+  pathname: '/color',
   query: {
-    bar: 'baz'
+    hex: '00f'
   },
-  navigationType: 'PUSH',
   state: {
     key: 'q7ugo9odofq7iudi'
-  },
-  params: {}
+  }
 };
 
 
@@ -49,31 +51,67 @@ function externalStateChange(state) {
 }
 
 const App = pure(() => (
-  <Connector select={s => s}>{({ dispatch, router }) => (
-    <div>
-      <p>Works with <code>{'<Link />'}</code>:</p>
-      <Link to="/foo?bar=baz">Foo</Link>
-      <Link to="/bar?baz=foo">Bar</Link>
-      <p>Works with <code>transitionTo()</code> action creator:</p>
-      <button onClick={() => dispatch(transitionTo('/foo?bar=baz'))}>Foo</button>
-      <button onClick={() => dispatch(transitionTo('/bar?baz=foo'))}>Bar</button>
-      <p>Works when store state is updated via some other mechanism like devtools or deserialization (check URL):</p>
-      <button onClick={() => dispatch(externalStateChange(fooState))}>Foo</button>
-      <button onClick={() => dispatch(externalStateChange(barState))}>Bar</button>
-      <p>Location: {JSON.stringify(router)}</p>
-    </div>
-  )}</Connector>
+  <div>
+    <Connector select={s => s}>{({ dispatch, router }) => (
+      <div style={{
+        backgroundColor: router.query && `#${router.query.hex}`,
+        color: '#fff',
+        transition: 'background-color 150ms ease-in-out',
+        position: 'fixed',
+        height: '100%',
+        width: '100%'
+      }}>
+        <p>Works with <code>{'<Link />'}</code>:</p>
+        <Link to="/color?hex=f00">Red</Link>
+        <Link to="/color?hex=00f">Blue</Link>
+        <p>Works with <code>transitionTo()</code> action creator:</p>
+        <button onClick={() => dispatch(transitionTo('/color?hex=f00'))}>Red</button>
+        <button onClick={() => dispatch(transitionTo('/color?hex=00f'))}>Blue</button>
+        <p>Works when store state is updated via some other mechanism like devtools or deserialization (check URL):</p>
+        <button onClick={() => dispatch(externalStateChange(redState))}>Red</button>
+        <button onClick={() => dispatch(externalStateChange(blueState))}>Blue</button>
+        <p>Location: {JSON.stringify(router)}</p>
+      </div>
+    )}</Connector>
+    <DebugPanel top right bottom>
+      <ReduxMonitor store={store} />
+    </DebugPanel>
+  </div>
 ));
 
 const Foo = pure(() => <div>Foo</div>);
 const Bar = pure(() => <div>Bar</div>);
 
+//history.listen(location => {
+  // update redux store
+  var location = new Location(req.url, req.query);
+
+  fetchData(location, (data) => {
+
+  })
+
+
+  React.render((
+    <Router location={location} />
+  ))
+//})
+
+router.match(location, (params, components) => {
+  React
+});
+
+store.subscribe(location, state => {
+
+});
+
+<Router location={location} />
+<Router history={history} />
+
 ReactDOM.render((
   <Router history={history}>
     <Route component={reduxRouteComponent(store)}>
       <Route path="/" component={App}>
-        <Route path="/foo" component={Foo} />
-        <Route path="/bar" component={Bar} />
+        <Route path="/color" component={Foo} />
       </Route>
     </Route>
   </Router>

--- a/examples/links/package.json
+++ b/examples/links/package.json
@@ -10,11 +10,14 @@
     "babel-core": "5.6.15",
     "babel-loader": "^5.1.4",
     "react-hot-loader": "^1.2.7",
+    "redux-batched-updates": "^0.1.0",
     "webpack": "^1.9.11",
     "webpack-dev-server": "^1.9.0"
   },
   "license": "MIT",
   "dependencies": {
-    "react-pure-component": "^0.1.0"
+    "react-pure-component": "^0.1.0",
+    "redux": "^1.0.0-alpha",
+    "react-redux": "^0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "react-dom": "0.14.0-beta1",
     "react-hot-loader": "^1.2.8",
     "react-router": "^1.0.0-beta3",
-    "redux": "git+https://github.com/acdlite/redux.git#36acbc8ec89e2ca4bf27667e1be5c286d6c12561",
+    "redux": "1.0.0-alpha",
     "sinon": "^1.15.4",
     "webpack": "^1.10.1"
-  }
+  },
+  "dependencies": {}
 }

--- a/src/__tests__/locationStateEquals-test.js
+++ b/src/__tests__/locationStateEquals-test.js
@@ -11,19 +11,4 @@ describe('locationStateEquals', () => {
       { key: 'lolwut' }
     )).to.be.false;
   });
-
-  it('returns true both are false-y', () => {
-    expect(locationStateEquals(
-      { key: null },
-      { key: undefined },
-    )).to.be.true;
-    expect(locationStateEquals(
-      { key: null },
-      { key: null },
-    )).to.be.true;
-    expect(locationStateEquals(
-      { key: null },
-      { key: 'hi' },
-    )).to.be.false;
-  });
 });

--- a/src/__tests__/reduxRouteComponent-test.js
+++ b/src/__tests__/reduxRouteComponent-test.js
@@ -6,6 +6,7 @@ import jsdom from './jsdom';
 import React, { Component, addons } from 'react/addons';
 import { Router, Route } from 'react-router';
 import MemoryHistory from 'react-router/lib/MemoryHistory';
+import sinon from 'sinon';
 const { TestUtils } = addons;
 
 describe('reduxRouteComponent', () => {
@@ -21,6 +22,9 @@ describe('reduxRouteComponent', () => {
         },
         state: {
           key: 'q7ugo9odofq7iudi'
+        },
+        params: {
+          extra: 'special-something'
         }
       }
     };
@@ -48,6 +52,7 @@ describe('reduxRouteComponent', () => {
     }
 
     let child;
+    const reducerSpy = sinon.spy();
     const steps = [
       function step1() {
         setImmediate(() => {
@@ -75,6 +80,7 @@ describe('reduxRouteComponent', () => {
         expect(child.props.pathname).to.equal('/two/special-something');
         expect(child.props.params).to.eql({ extra: 'special-something' });
         expect(child.props.query).to.eql({ baz: 'foo' });
+        expect(reducerSpy.callCount).to.equal(5);
         done();
       }
     ];
@@ -84,6 +90,7 @@ describe('reduxRouteComponent', () => {
     }
 
     function reducer(state = {}, action) {
+      reducerSpy();
       return {
         router: routerStateReducer(state, action)
       };

--- a/src/locationStateEquals.js
+++ b/src/locationStateEquals.js
@@ -1,6 +1,5 @@
 /**
- * Check if two location states are equal, using location.key. If both keys are
- * non-existent, return true.
+ * Check if two location states are equal, using location.key.
  * @param [object] l1 - Location state (HTML5 pushState)
  * @param [object] l2 - Location state (HTML5 pushState)
  * @returns {Boolean}
@@ -8,6 +7,5 @@
 export default function locationStateEquals(l1, l2) {
   const l1Key = l1 && l1.key;
   const l2Key = l2 && l2.key;
-
-  return (!l1Key && !l2Key) || (l1Key === l2Key);
+  return l1Key === l2Key;
 }


### PR DESCRIPTION
Noticed after testing with Redux Devtools that an extra, unnecessary action was being dispatched after an external state change. This PR fixes it by comparing location state keys before calling `locationDidChange()`.