### PR TITLE
Add repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "test": "make test",
     "prepublish": "make clean build"
   },
+  "repository":{
+    "type": "git",
+    "url": "git://github.com/acdlite/redux-react-router.git"
+  },
   "keywords": [
     "redux",
     "react-router",


### PR DESCRIPTION
This lets people click on the repository link on npmjs.org