### PR TITLE
add test case for expected onEnter hook redirect

### DIFF
--- a/src/__tests__/reduxReactRouter-test.js
+++ b/src/__tests__/reduxReactRouter-test.js
@@ -166,4 +166,41 @@ describe('reduxRouter()', () => {
         .to.equal('/parent/child/123');
     });
   });
+
+  describe('onEnter hook', () => {
+    it('sends user to the pushstate location', () => {
+      const reducer = combineReducers({
+        router: routerStateReducer
+      });
+
+      let dispatch;
+      let getState;
+      const history = createHistory();
+
+      reduxReactRouter({
+        history,
+        getRoutes: (d, gs) => {
+          const requireAuth = (nextState, redirectTo) => {
+            dispatch(pushState({}, "/login"));
+          };
+          const routes = (
+            <Route path="/">
+              <Route path="parent">
+                <Route path="child/:id" onEnter={requireAuth}/>
+              </Route>
+              <Route path="login" />
+            </Route>
+          );
+          dispatch = d;
+          getState = gs;
+          return routes;
+        }
+      })(createStore)(reducer);
+
+      dispatch(pushState(null, '/parent/child/123', { key: 'value'}));
+      expect(getState().router.location.pathname)
+        .to.equal('/login');
+    });
+  });
+
 });


### PR DESCRIPTION
onEnter hook is ofter used to trigger a redirect based on checking some
preconditions like a session token.  This test case verifies the
expected behaviour that a pushState change in onEnter would redirect the
user to the new location.