### PR TITLE
Server-rendering API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 coverage
 *.log
 lib
-server.js
+/server.js

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 *.log
 lib
+server.js

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Redux bindings for React Router — keep your router state inside your Redux Store.",
   "main": "lib/index.js",
   "scripts": {
-    "build": "babel src --out-dir lib",
-    "clean": "rimraf lib",
+    "build": "babel src --out-dir lib && cp lib/server.js server.js",
+    "clean": "rimraf lib && rimraf server.js",
     "lint": "eslint src",
     "test": "mocha --compilers js:babel/register --recursive --require src/__tests__/init.js src/**/*-test.js",
     "test-watch": "mocha --compilers js:babel/register --recursive --require src/__tests__/init.js -w src/**/*-test.js",
@@ -39,6 +39,7 @@
     "node-libs-browser": "^0.5.2",
     "react": "0.14.0-rc1",
     "react-addons-test-utils": "^0.14.0-rc1",
+    "react-dom": "^0.14.0-rc1",
     "react-redux": "2.x",
     "react-router": "1.0.0-rc1",
     "redux": "3.x",

--- a/src/client.js
+++ b/src/client.js
@@ -1,0 +1,49 @@
+import { compose } from 'redux';
+import { routerDidChange } from './actionCreators';
+import routerStateEquals from './routerStateEquals';
+import reduxReactRouter from './reduxReactRouter';
+import transformOptions from './transformOptions';
+
+function client(next) {
+  return options => createStore => (reducer, initialState) => {
+    const { onError, routerStateSelector } = options;
+    const store = next(options)(createStore)(reducer, initialState);
+    const { history } = store;
+
+    let routerState;
+
+    history.listen((error, nextRouterState) => {
+      if (error) {
+        onError(error);
+        return;
+      }
+
+      const prevRouterState = routerStateSelector(store.getState());
+
+      if (!routerStateEquals(prevRouterState, nextRouterState)) {
+        store.dispatch(routerDidChange(nextRouterState));
+      }
+    });
+
+    store.subscribe(() => {
+      const nextRouterState = routerStateSelector(store.getState());
+
+      if (
+        nextRouterState &&
+        !routerStateEquals(routerState, nextRouterState)
+      ) {
+        const { state, pathname, query } = nextRouterState.location;
+        history.replaceState(state, pathname, query);
+      }
+
+      routerState = nextRouterState;
+    });
+
+    return store;
+  };
+}
+
+export default compose(
+  transformOptions,
+  client
+)(reduxReactRouter);

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,5 +3,6 @@
 // redux-react-router.
 export const ROUTER_DID_CHANGE = '@@reduxReactRouter/routerDidChange';
 export const HISTORY_API = '@@reduxReactRouter/historyAPI';
+export const MATCH = '@@reduxReactRouter/match';
 
 export const ROUTER_STATE_SELECTOR = '@@reduxReactRouter/routerStateSelector';

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 export routerStateReducer from './routerStateReducer';
 export ReduxRouter from './ReduxRouter';
-export reduxReactRouter from './reduxReactRouter';
+export reduxReactRouter from './client';
 
 export {
   historyAPI,

--- a/src/matchMiddleware.js
+++ b/src/matchMiddleware.js
@@ -1,0 +1,19 @@
+import createLocation from 'history/lib/createLocation';
+import { routerDidChange } from './actionCreators';
+import { MATCH } from './constants';
+
+export default function matchMiddleware(match) {
+  return ({ dispatch }) => next => action => {
+    if (action.type === MATCH) {
+      const { url, callback } = action.payload;
+      const location = createLocation(url);
+      match(location, (error, redirectLocation, routerState) => {
+        if (!error && !redirectLocation) {
+          dispatch(routerDidChange(routerState));
+        }
+        callback(error, redirectLocation, routerState);
+      });
+    }
+    return next(action);
+  };
+}

--- a/src/reduxReactRouter.js
+++ b/src/reduxReactRouter.js
@@ -1,83 +1,29 @@
-import historyMiddleware from './historyMiddleware';
-import { routerDidChange } from './actionCreators';
-import routerStateEquals from './routerStateEquals';
 import { applyMiddleware } from 'redux';
-import { useRoutes, createRoutes } from 'react-router';
+import { useRoutes } from 'react-router';
+import historyMiddleware from './historyMiddleware';
 import { ROUTER_STATE_SELECTOR } from './constants';
 
-const defaults = {
-  onError: error => { throw error; },
-  routerStateSelector: state => state.router
-};
-
-export default function reduxReactRouter(options) {
+export default function reduxReactRouter({
+  routes,
+  createHistory,
+  parseQueryString,
+  stringifyQuery,
+  routerStateSelector
+}) {
   return createStore => (reducer, initialState) => {
-    const {
-      routes: baseRoutes,
-      getRoutes,
-      history: baseHistory,
-      createHistory: baseCreateHistory,
-      parseQueryString,
-      stringifyQuery,
-      onError,
-      routerStateSelector
-    } = { ...defaults, ...options };
-
-    let routerState;
-    let store;
-
-    function dispatch(action) {
-      if (store) return store.dispatch(action);
-    }
-
-    function getState() {
-      if (store) return store.getState();
-    }
-
-    const routes = typeof getRoutes === 'function'
-      ? getRoutes(dispatch, getState)
-      : baseRoutes;
-    const createHistory = baseCreateHistory || (() => baseHistory);
     const history = useRoutes(createHistory)({
-      routes: createRoutes(routes),
+      routes,
       parseQueryString,
       stringifyQuery
     });
 
-    store =
+    const store =
       applyMiddleware(
         historyMiddleware(history)
       )(createStore)(reducer, initialState);
 
     store.history = history;
     store[ROUTER_STATE_SELECTOR] = routerStateSelector;
-
-    history.listen((error, nextRouterState) => {
-      if (error) {
-        onError(error);
-        return;
-      }
-
-      const prevRouterState = routerStateSelector(store.getState());
-
-      if (!routerStateEquals(prevRouterState, nextRouterState)) {
-        store.dispatch(routerDidChange(nextRouterState));
-      }
-    });
-
-    store.subscribe(() => {
-      const nextRouterState = routerStateSelector(getState());
-
-      if (
-        nextRouterState &&
-        !routerStateEquals(routerState, nextRouterState)
-      ) {
-        const { state, pathname, query } = nextRouterState.location;
-        history.replaceState(state, pathname, query);
-      }
-
-      routerState = nextRouterState;
-    });
 
     return store;
   };

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,36 @@
+import { compose, applyMiddleware } from 'redux';
+import createMemoryHistory from 'history/lib/createMemoryHistory';
+import baseReduxReactRouter from './reduxReactRouter';
+import transformOptions from './transformOptions';
+import matchMiddleware from './matchMiddleware';
+import { MATCH } from './constants';
+
+function server(next) {
+  return options => createStore => (reducer, initialState) => {
+    const store = compose(
+      applyMiddleware(
+        matchMiddleware((...args) => store.history.match(...args))
+      ),
+      next({
+        ...options,
+        createHistory: options.createHistory || createMemoryHistory
+      })
+    )(createStore)(reducer, initialState);
+    return store;
+  };
+}
+
+export function match(url, callback) {
+  return {
+    type: MATCH,
+    payload: {
+      url,
+      callback
+    }
+  };
+}
+
+export const reduxReactRouter = compose(
+  transformOptions,
+  server
+)(baseReduxReactRouter);

--- a/src/transformOptions.js
+++ b/src/transformOptions.js
@@ -1,0 +1,44 @@
+import { createRoutes } from 'react-router';
+
+const defaults = {
+  onError: error => { throw error; },
+  routerStateSelector: state => state.router
+};
+
+export default function transformOptions(next) {
+  return options => createStore => (reducer, initialState) => {
+    const {
+      routes: baseRoutes,
+      getRoutes,
+      createHistory: baseCreateHistory,
+      history: baseHistory
+    } = options;
+
+    const createHistory = !baseCreateHistory && baseHistory
+      ? () => baseHistory
+      : null;
+
+    let store;
+
+    function dispatch(action) {
+      return store.dispatch(action);
+    }
+
+    function getState() {
+      return store.getState();
+    }
+
+    const routes = typeof getRoutes === 'function'
+      ? getRoutes(dispatch, getState)
+      : baseRoutes;
+
+    store = next({
+      ...defaults,
+      ...options,
+      routes: createRoutes(routes),
+      createHistory
+    })(createStore)(reducer, initialState);
+
+    return store;
+  };
+}


### PR DESCRIPTION
It looks like this:

```js
import { reduxReactRouter, match } from 'redux-react-router';

// Omit history (or createHistory) from options
const store = reduxReactRouter({ routes })(createStore)(reducer);

store.dispatch(match('/parent/child/850', (error, redirectLocation) => {
  if (error) // handle error

  if (redirectLocation) // handle redirect

  res.send(
    // Render like normal
    renderToString(
      <Provider store={store}>
        <ReduxRouter />
      </Provider>
    )
  );
}));
```