### PR TITLE
Dynamic routes

### DIFF
--- a/src/ReduxRouter.js
+++ b/src/ReduxRouter.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { RoutingContext } from 'react-router';
 import routerStateEquals from './routerStateEquals';
 import { ROUTER_STATE_SELECTOR } from './constants';
+import { replaceRoutes } from './actionCreators';
 
 function memoizeRouterStateSelector(selector) {
   let previousRouterState = null;
@@ -17,9 +18,31 @@ function memoizeRouterStateSelector(selector) {
   };
 }
 
+function getRoutesFromProps(props) {
+  return props.routes || props.children;
+}
+
 class ReduxRouter extends Component {
+  static propTypes = {
+    children: PropTypes.node
+  }
+
   static contextTypes = {
     store: PropTypes.object
+  }
+
+  constructor(props, context) {
+    super(props, context);
+    this.receiveRoutes(getRoutesFromProps(props));
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.receiveRoutes(getRoutesFromProps(nextProps));
+  }
+
+  receiveRoutes(routes) {
+    const { store } = this.context;
+    store.dispatch(replaceRoutes(routes));
   }
 
   render() {

--- a/src/__tests__/ReduxRouter-test.js
+++ b/src/__tests__/ReduxRouter-test.js
@@ -68,6 +68,7 @@ function redirectOnEnter(pathname) {
 const routes = (
   <Route path="/" component={App} onEnter={redirectOnEnter}>
     <Route path="parent" component={Parent}>
+      <Route path="child" component={Child} />
       <Route path="child/:id" component={Child} />
     </Route>
     <Route path="redirect" onEnter={redirectOnEnter('/parent/child/850')} />
@@ -149,6 +150,41 @@ describe('<ReduxRouter>', () => {
         expect(error).to.be.null;
         expect(redirectLocation.pathname).to.equal('/parent/child/850');
       }));
+    });
+  });
+
+  describe('dynamic route switching', () => {
+    it('updates routes wnen <ReduxRouter> receives new props', () => {
+      const newRoutes = (
+        <Route path="/parent/:route" component={App} />
+      );
+
+      const reducer = combineReducers({
+        router: routerStateReducer
+      });
+
+      const history = createHistory();
+      const store = reduxReactRouter({ history })(createStore)(reducer);
+
+      class RouterContainer extends Component {
+        state = { routes }
+
+        render() {
+          return (
+            <Provider store={store}>
+              <ReduxRouter routes={this.state.routes} />
+            </Provider>
+          );
+        }
+      }
+
+      history.pushState(null, '/parent/child');
+      const tree = renderIntoDocument(<RouterContainer />);
+
+
+      expect(store.getState().router.params).to.eql({});
+      tree.setState({ routes: newRoutes });
+      expect(store.getState().router.params).to.eql({ route: 'child' });
     });
   });
 });

--- a/src/__tests__/ReduxRouter-test.js
+++ b/src/__tests__/ReduxRouter-test.js
@@ -85,15 +85,16 @@ describe('<ReduxRouter>', () => {
 
     const history = createHistory();
     const store = reduxReactRouter({
-      history,
-      routes
+      history
     })(createStore)(reducer);
 
     history.pushState(null, '/parent/child/123?key=value');
 
     return renderIntoDocument(
       <Provider store={store}>
-        <ReduxRouter />
+        <ReduxRouter>
+          {routes}
+        </ReduxRouter>
       </Provider>
     );
   }

--- a/src/__tests__/reduxReactRouter-test.js
+++ b/src/__tests__/reduxReactRouter-test.js
@@ -171,5 +171,4 @@ describe('reduxRouter()', () => {
         .to.equal('/login');
     });
   });
-
 });

--- a/src/__tests__/reduxReactRouter-test.js
+++ b/src/__tests__/reduxReactRouter-test.js
@@ -95,10 +95,8 @@ describe('reduxRouter()', () => {
       router: routerStateReducer
     });
 
-    const history = createHistory();
-
     const store = reduxReactRouter({
-      history,
+      createHistory,
       routes
     })(createStore)(reducer);
 

--- a/src/__tests__/reduxReactRouter-test.js
+++ b/src/__tests__/reduxReactRouter-test.js
@@ -142,31 +142,6 @@ describe('reduxRouter()', () => {
     expect(store.getState().string).to.equal('Unidirectional');
   });
 
-  describe('getRoutes()', () => {
-    it('is passed dispatch and getState', () => {
-      const reducer = combineReducers({
-        router: routerStateReducer
-      });
-
-      let dispatch;
-      let getState;
-      const history = createHistory();
-
-      reduxReactRouter({
-        history,
-        getRoutes: (d, gs) => {
-          dispatch = d;
-          getState = gs;
-          return routes;
-        }
-      })(createStore)(reducer);
-
-      dispatch(pushState(null, '/parent/child/123', { key: 'value'}));
-      expect(getState().router.location.pathname)
-        .to.equal('/parent/child/123');
-    });
-  });
-
   describe('onEnter hook', () => {
     it('can perform redirects', () => {
       const reducer = combineReducers({
@@ -175,21 +150,20 @@ describe('reduxRouter()', () => {
 
       const history = createHistory();
 
+      const requireAuth = (nextState, _replaceState) => {
+        _replaceState(null, '/login');
+      };
+
       const store = reduxReactRouter({
         history,
-        getRoutes: () => {
-          const requireAuth = (nextState, _replaceState) => {
-            _replaceState(null, '/login');
-          };
-          return (
-            <Route path="/">
-              <Route path="parent">
-                <Route path="child/:id" onEnter={requireAuth}/>
-              </Route>
-              <Route path="login" />
+        routes: (
+          <Route path="/">
+            <Route path="parent">
+              <Route path="child/:id" onEnter={requireAuth}/>
             </Route>
-          );
-        }
+            <Route path="login" />
+          </Route>
+        )
       })(createStore)(reducer);
 
       store.dispatch(pushState(null, '/parent/child/123', { key: 'value'}));

--- a/src/actionCreators.js
+++ b/src/actionCreators.js
@@ -1,4 +1,4 @@
-import { ROUTER_DID_CHANGE, HISTORY_API } from './constants';
+import { ROUTER_DID_CHANGE, REPLACE_ROUTES, HISTORY_API } from './constants';
 
 /**
  * Action creator for signaling that the router has changed.
@@ -10,6 +10,18 @@ export function routerDidChange(state) {
   return {
     type: ROUTER_DID_CHANGE,
     payload: state
+  };
+}
+
+/**
+ * Action creator that replaces the current route config
+ * @private
+ * @param {Array<Route>|ReactElement} routes - New routes
+ */
+export function replaceRoutes(routes) {
+  return {
+    type: REPLACE_ROUTES,
+    payload: routes
   };
 }
 

--- a/src/client.js
+++ b/src/client.js
@@ -2,7 +2,8 @@ import { compose } from 'redux';
 import { routerDidChange } from './actionCreators';
 import routerStateEquals from './routerStateEquals';
 import reduxReactRouter from './reduxReactRouter';
-import transformOptions from './transformOptions';
+import useDefaults from './useDefaults';
+import routeReplacement from './routeReplacement';
 
 function client(next) {
   return options => createStore => (reducer, initialState) => {
@@ -44,6 +45,7 @@ function client(next) {
 }
 
 export default compose(
-  transformOptions,
+  useDefaults,
+  routeReplacement,
   client
 )(reduxReactRouter);

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,5 +4,6 @@
 export const ROUTER_DID_CHANGE = '@@reduxReactRouter/routerDidChange';
 export const HISTORY_API = '@@reduxReactRouter/historyAPI';
 export const MATCH = '@@reduxReactRouter/match';
+export const REPLACE_ROUTES = '@@reduxReactRouter/replaceRoutes';
 
 export const ROUTER_STATE_SELECTOR = '@@reduxReactRouter/routerStateSelector';

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,8 +2,11 @@
 // never be called by the application, only as an implementation detail of
 // redux-react-router.
 export const ROUTER_DID_CHANGE = '@@reduxReactRouter/routerDidChange';
+
 export const HISTORY_API = '@@reduxReactRouter/historyAPI';
 export const MATCH = '@@reduxReactRouter/match';
 export const REPLACE_ROUTES = '@@reduxReactRouter/replaceRoutes';
 
 export const ROUTER_STATE_SELECTOR = '@@reduxReactRouter/routerStateSelector';
+
+export const DOES_NEED_REFRESH = '@@reduxReactRouter/doesNeedRefresh';

--- a/src/replaceRoutesMiddleware.js
+++ b/src/replaceRoutesMiddleware.js
@@ -1,0 +1,10 @@
+import { REPLACE_ROUTES } from './constants';
+
+export default function replaceRoutesMiddleware(replaceRoutes) {
+  return () => next => action => {
+    if (action.type === REPLACE_ROUTES) {
+      replaceRoutes(action.payload);
+    }
+    return next(action);
+  };
+}

--- a/src/routeReplacement.js
+++ b/src/routeReplacement.js
@@ -2,25 +2,14 @@ import { applyMiddleware, compose } from 'redux';
 import { createRoutes } from 'react-router';
 import replaceRoutesMiddleware from './replaceRoutesMiddleware';
 
-const defaults = {
-  onError: error => { throw error; },
-  routerStateSelector: state => state.router
-};
-
-export default function transformOptions(next) {
+export default function routeReplacement(next) {
   return options => createStore => (reducer, initialState) => {
     const {
       routes: baseRoutes,
-      createHistory: baseCreateHistory,
-      history: baseHistory,
       routerStateSelector
-    } = { ...defaults, ...options };
+    } = options;
 
     let store;
-
-    const createHistory = !baseCreateHistory && baseHistory
-      ? () => baseHistory
-      : null;
 
     let childRoutes = [];
     let areChildRoutesResolved = false;
@@ -59,10 +48,8 @@ export default function transformOptions(next) {
         replaceRoutesMiddleware(replaceRoutes)
       ),
       next({
-        ...defaults,
         ...options,
-        routes: createRoutes(routes),
-        createHistory
+        routes: createRoutes(routes)
       })
     )(createStore)(reducer, initialState);
 

--- a/src/routerStateEquals.js
+++ b/src/routerStateEquals.js
@@ -1,4 +1,5 @@
 import deepEqual from 'deep-equal';
+import { DOES_NEED_REFRESH } from './constants';
 
 /**
  * Check if two router states are equal. Ignores `location.key`.
@@ -7,6 +8,7 @@ import deepEqual from 'deep-equal';
 export default function routerStateEquals(a, b) {
   if (!a && !b) return true;
   if ((a && !b) || (!a && b)) return false;
+  if (a[DOES_NEED_REFRESH] || b[DOES_NEED_REFRESH]) return false;
 
   return (
     a.location.pathname === b.location.pathname &&

--- a/src/routerStateReducer.js
+++ b/src/routerStateReducer.js
@@ -1,4 +1,8 @@
-import { ROUTER_DID_CHANGE } from './constants';
+import {
+  ROUTER_DID_CHANGE,
+  REPLACE_ROUTES,
+  DOES_NEED_REFRESH
+} from './constants';
 
 /**
  * Reducer of ROUTER_DID_CHANGE actions. Returns a state object
@@ -8,7 +12,15 @@ import { ROUTER_DID_CHANGE } from './constants';
  * @return {Object} New state
  */
 export default function routerStateReducer(state = null, action) {
-  return action.type === ROUTER_DID_CHANGE
-    ? action.payload
-    : state;
+  switch (action.type) {
+  case ROUTER_DID_CHANGE:
+    return action.payload;
+  case REPLACE_ROUTES:
+    return {
+      ...state,
+      [DOES_NEED_REFRESH]: true
+    };
+  default:
+    return state;
+  }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,8 @@
 import { compose, applyMiddleware } from 'redux';
 import createMemoryHistory from 'history/lib/createMemoryHistory';
 import baseReduxReactRouter from './reduxReactRouter';
-import transformOptions from './transformOptions';
+import useDefaults from './useDefaults';
+import routeReplacement from './routeReplacement';
 import matchMiddleware from './matchMiddleware';
 import { MATCH } from './constants';
 
@@ -31,6 +32,7 @@ export function match(url, callback) {
 }
 
 export const reduxReactRouter = compose(
-  transformOptions,
+  useDefaults,
+  routeReplacement,
   server
 )(baseReduxReactRouter);

--- a/src/transformOptions.js
+++ b/src/transformOptions.js
@@ -12,8 +12,11 @@ export default function transformOptions(next) {
     const {
       routes: baseRoutes,
       createHistory: baseCreateHistory,
-      history: baseHistory
-    } = options;
+      history: baseHistory,
+      routerStateSelector
+    } = { ...defaults, ...options };
+
+    let store;
 
     const createHistory = !baseCreateHistory && baseHistory
       ? () => baseHistory
@@ -25,6 +28,12 @@ export default function transformOptions(next) {
 
     function replaceRoutes(r) {
       childRoutes = createRoutes(r);
+
+      const routerState = routerStateSelector(store.getState());
+      if (routerState) {
+        const { state, pathname, query } = routerState.location;
+        store.history.replaceState(state, pathname, query);
+      }
 
       if (!areChildRoutesResolved) {
         areChildRoutesResolved = true;
@@ -45,7 +54,7 @@ export default function transformOptions(next) {
         }
       }];
 
-    const store =  compose(
+    store = compose(
       applyMiddleware(
         replaceRoutesMiddleware(replaceRoutes)
       ),

--- a/src/transformOptions.js
+++ b/src/transformOptions.js
@@ -11,7 +11,6 @@ export default function transformOptions(next) {
   return options => createStore => (reducer, initialState) => {
     const {
       routes: baseRoutes,
-      getRoutes,
       createHistory: baseCreateHistory,
       history: baseHistory
     } = options;
@@ -19,16 +18,6 @@ export default function transformOptions(next) {
     const createHistory = !baseCreateHistory && baseHistory
       ? () => baseHistory
       : null;
-
-    let store;
-
-    function dispatch(action) {
-      return store.dispatch(action);
-    }
-
-    function getState() {
-      return store.getState();
-    }
 
     let childRoutes = [];
     let areChildRoutesResolved = false;
@@ -43,13 +32,9 @@ export default function transformOptions(next) {
       }
     }
 
-    let routes;
-    if (typeof getRoutes === 'function') {
-      routes = getRoutes(dispatch, getState);
-    } else if (baseRoutes) {
-      routes = baseRoutes;
-    } else {
-      routes = [{
+    const routes = baseRoutes
+      ? baseRoutes
+      : [{
         getChildRoutes: (location, cb) => {
           if (!areChildRoutesResolved) {
             childRoutesCallbacks.push(cb);
@@ -59,9 +44,8 @@ export default function transformOptions(next) {
           cb(null, childRoutes);
         }
       }];
-    }
 
-    store =  compose(
+    const store =  compose(
       applyMiddleware(
         replaceRoutesMiddleware(replaceRoutes)
       ),

--- a/src/transformOptions.js
+++ b/src/transformOptions.js
@@ -1,4 +1,6 @@
+import { applyMiddleware, compose } from 'redux';
 import { createRoutes } from 'react-router';
+import replaceRoutesMiddleware from './replaceRoutesMiddleware';
 
 const defaults = {
   onError: error => { throw error; },
@@ -28,16 +30,48 @@ export default function transformOptions(next) {
       return store.getState();
     }
 
-    const routes = typeof getRoutes === 'function'
-      ? getRoutes(dispatch, getState)
-      : baseRoutes;
+    let childRoutes = [];
+    let areChildRoutesResolved = false;
+    const childRoutesCallbacks = [];
 
-    store = next({
-      ...defaults,
-      ...options,
-      routes: createRoutes(routes),
-      createHistory
-    })(createStore)(reducer, initialState);
+    function replaceRoutes(r) {
+      childRoutes = createRoutes(r);
+
+      if (!areChildRoutesResolved) {
+        areChildRoutesResolved = true;
+        childRoutesCallbacks.forEach(cb => cb(null, childRoutes));
+      }
+    }
+
+    let routes;
+    if (typeof getRoutes === 'function') {
+      routes = getRoutes(dispatch, getState);
+    } else if (baseRoutes) {
+      routes = baseRoutes;
+    } else {
+      routes = [{
+        getChildRoutes: (location, cb) => {
+          if (!areChildRoutesResolved) {
+            childRoutesCallbacks.push(cb);
+            return;
+          }
+
+          cb(null, childRoutes);
+        }
+      }];
+    }
+
+    store =  compose(
+      applyMiddleware(
+        replaceRoutesMiddleware(replaceRoutes)
+      ),
+      next({
+        ...defaults,
+        ...options,
+        routes: createRoutes(routes),
+        createHistory
+      })
+    )(createStore)(reducer, initialState);
 
     return store;
   };

--- a/src/useDefaults.js
+++ b/src/useDefaults.js
@@ -1,0 +1,29 @@
+const defaults = {
+  onError: error => { throw error; },
+  routerStateSelector: state => state.router
+};
+
+export default function useDefaults(next) {
+  return options => createStore => (reducer, initialState) => {
+    const optionsWithDefaults = { ...defaults, ...options };
+
+    const {
+      createHistory: baseCreateHistory,
+      history: baseHistory,
+    } = optionsWithDefaults;
+
+    let createHistory;
+    if (typeof baseCreateHistory === 'function') {
+      createHistory = baseCreateHistory;
+    } else if (baseHistory) {
+      createHistory = () => baseHistory;
+    } else {
+      createHistory = null;
+    }
+
+    return next({
+      ...optionsWithDefaults,
+      createHistory
+    })(createStore)(reducer, initialState);
+  };
+}


### PR DESCRIPTION
Allows routes to be specified as children (or `routes` prop) of `<ReduxRouter>`.

Example

```js
React.render((
  <Provider store={store}>
    <ReduxRouter>
      <Route path="/" component={App}>
        <Route path="parent" component={Parent}>
          <Route path="child/:id" component={Child} />
        </Route>
      </Route>
    </ReduxRouter>
  </Provider>
), el);
```

or, equivalently:

```js
const routes = (
  <Route path="/" component={App}>
    <Route path="parent" component={Parent}>
      <Route path="child/:id" component={Child} />
    </Route>
  </Route>
);

React.render((
  <Provider store={store}>
    <ReduxRouter routes={routes} />
  </Provider>
), el);
```

This solves the circular dependency problem (https://github.com/acdlite/redux-react-router/issues/44) and also enables hot-reloading via tools like react-transform-webpack-hmr (https://github.com/acdlite/redux-react-router/issues/44#issuecomment-140198502).