### PR TITLE
Add failing server-rendering tests

### DIFF
--- a/src/__tests__/ReduxRouter-test.js
+++ b/src/__tests__/ReduxRouter-test.js
@@ -124,7 +124,7 @@ describe('<ReduxRouter>', () => {
   });
 
   describe('server-side rendering', () => {
-    it('works', () => {
+    it('works', (done) => {
       const reducer = combineReducers({
         router: routerStateReducer
       });
@@ -137,10 +137,30 @@ describe('<ReduxRouter>', () => {
           </Provider>
         );
         expect(output).to.match(/Pathname: \/parent\/child\/850/);
+        done();
       }));
     });
 
-    it('handles redirects', () => {
+    it('works with dynamic routes', (done) => {
+      const reducer = combineReducers({
+        router: routerStateReducer
+      });
+
+      const store = server.reduxReactRouter()(createStore)(reducer);
+      store.dispatch(server.match('/parent/child/850', () => {
+        const output = renderToString(
+          <Provider store={store}>
+            <ReduxRouter>
+               {routes}
+            </ReduxRouter>
+          </Provider>
+        );
+        expect(output).to.match(/Pathname: \/parent\/child\/850/);
+        done();
+      }));
+    });
+
+    it('handles redirects', (done) => {
       const reducer = combineReducers({
         router: routerStateReducer
       });
@@ -149,6 +169,7 @@ describe('<ReduxRouter>', () => {
       store.dispatch(server.match('/redirect', (error, redirectLocation) => {
         expect(error).to.be.null;
         expect(redirectLocation.pathname).to.equal('/parent/child/850');
+        done();
       }));
     });
   });


### PR DESCRIPTION
Continuing my utter nonsense from here: https://github.com/acdlite/redux-react-router/pull/47

This PR adds a failing test for server-side rendering with dynamic routes. Of curse I tried to fix the issue and I think I came really far, but it ended for me in `routeReplacement.js`.

react-routers `match` will traverse the routes and tries to resolve all child routes in:
https://github.com/rackt/react-router/blob/master/modules/matchRoutes.js#L9
which will then call:
https://github.com/acdlite/redux-react-router/blob/master/src/routeReplacement.js#L37
Now the callback from `getChildRoutes` will never be resolved - therefore the `match` callback will also never be resolved and it just ends here. The `replaceRoutes` action will never fire.

On a side node: This also adds proper async handling of the server-side rendering tests. 