### PR TITLE
Add isActive()

### DIFF
--- a/src/__tests__/reduxReactRouter-test.js
+++ b/src/__tests__/reduxReactRouter-test.js
@@ -2,7 +2,8 @@ import {
   reduxReactRouter,
   routerStateReducer,
   pushState,
-  replaceState
+  replaceState,
+  isActive
 } from '../';
 
 import { createStore, combineReducers } from 'redux';
@@ -190,6 +191,26 @@ describe('reduxRouter()', () => {
       store.dispatch(pushState(null, '/parent/child/123', { key: 'value'}));
       expect(store.getState().router.location.pathname)
         .to.equal('/login');
+    });
+
+    describe('isActive', () => {
+      it('creates a selector for whether a pathname/query pair is active', () => {
+        const reducer = combineReducers({
+          router: routerStateReducer
+        });
+
+        const history = createHistory();
+
+        const store = reduxReactRouter({
+          history,
+          routes
+        })(createStore)(reducer);
+
+        const activeSelector = isActive('/parent', { key: 'value' });
+        expect(activeSelector(store.getState().router)).to.be.false;
+        history.pushState(null, '/parent?key=value');
+        expect(activeSelector(store.getState().router)).to.be.true;
+      });
     });
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 export routerStateReducer from './routerStateReducer';
 export ReduxRouter from './ReduxRouter';
 export reduxReactRouter from './client';
+export isActive from './isActive';
 
 export {
   historyAPI,

--- a/src/isActive.js
+++ b/src/isActive.js
@@ -1,0 +1,17 @@
+import _isActive from 'react-router/lib/isActive';
+
+/**
+ * Creates a router state selector that returns whether or not the given
+ * pathname and query are active.
+ * @param {String} pathname
+ * @param {Object} query
+ * @param {Boolean} indexOnly
+ * @return {Boolean}
+ */
+export default function isActive(pathname, query, indexOnly = false) {
+  return state => {
+    if (!state) return false;
+    const { location, params, routes } = state;
+    return _isActive(pathname, query, indexOnly, location, routes, params);
+  };
+}


### PR DESCRIPTION
`isActive(pathname, query)` creates a state selector that returns whether or not the given pathname and query are active.

The resulting selector should be passed the *router* state, not the entire store state. With reselect, you would use it like this:

```js
import { isActive } from 'redux-react-router'; 

const routerStateSelector = state => state.router;

const selector = createSelector(
  routerStateSelector,
  isActive('/some/path', { key: 'path' })
);
```